### PR TITLE
Add name and parent_const accessor for constant nodes with a namespace

### DIFF
--- a/lib/synvert/core/node_ext.rb
+++ b/lib/synvert/core/node_ext.rb
@@ -24,7 +24,7 @@ module Parser::AST
 
   # Parser::AST::Node monkey patch.
   class Node
-    # Get name node of :class, :module, :def and :defs node.
+    # Get name node of :class, :module, :const, :def and :defs node.
     #
     # @return [Parser::AST::Node] name node.
     # @raise [Synvert::Core::MethodNotSupported] if calls on other node.
@@ -32,7 +32,7 @@ module Parser::AST
       case self.type
       when :class, :module, :def, :arg, :blockarg
         self.children[0]
-      when :defs
+      when :defs, :const
         self.children[1]
       else
         raise Synvert::Core::MethodNotSupported.new "name is not handled for #{self.debug_info}"
@@ -48,6 +48,18 @@ module Parser::AST
         self.children[1]
       else
         raise Synvert::Core::MethodNotSupported.new "parent_class is not handled for #{self.debug_info}"
+      end
+    end
+
+    # Get parent constant node of :const node.
+    #
+    # @return [Parser::AST::Node] parent const node.
+    # @raise [Synvert::Core::MethodNotSupported] if calls on other node.
+    def parent_const
+      if :const == self.type
+        self.children[0]
+      else
+        raise Synvert::Core::MethodNotSupported.new "parent_const is not handled for #{self.debug_info}"
       end
     end
 

--- a/spec/synvert/core/node_ext_spec.rb
+++ b/spec/synvert/core/node_ext_spec.rb
@@ -34,6 +34,12 @@ describe Parser::AST::Node do
       node = parse('def test(&block); end')
       expect(node.arguments.first.name).to eq :block
     end
+
+    it 'gets for const node' do
+      node = parse('Synvert')
+      expect(node.name).to eq :Synvert
+    end
+
   end
 
   describe '#parent_class' do
@@ -54,6 +60,23 @@ describe Parser::AST::Node do
     it 'gets for send node' do
       node = parse('FactoryGirl.create :post')
       expect(node.message).to eq :create
+    end
+  end
+
+  describe '#parent_const' do
+    it 'gets for const node' do
+      node = parse('Synvert::Node')
+      expect(node.parent_const).to eq parse('Synvert')
+    end
+
+    it 'gets for const node at the root' do
+      node = parse('::Node')
+      expect(node.parent_const.type).to eq :cbase
+    end
+
+    it 'gets for const node with no parent' do
+      node = parse('Node')
+      expect(node.parent_const).to eq nil
     end
   end
 


### PR DESCRIPTION
It'd be nice to be able to access the name and the sometimes-present parent constant in a constant node, and be able to match against them. 

Anywhere else I need to update? 