### PR TITLE
Auto corrected by following Lint Ruby EmptyLine

### DIFF
--- a/lib/synvert/core/node_ext.rb
+++ b/lib/synvert/core/node_ext.rb
@@ -133,9 +133,11 @@ module Parser::AST
         self.children
       when :def, :block
         return [] if self.children[2].nil?
+
         :begin == self.children[2].type ? self.children[2].body : self.children[2..-1]
       when :defs
         return [] if self.children[3].nil?
+
         :begin == self.children[3].type ? self.children[3].body : self.children[3..-1]
       else
         raise Synvert::Core::MethodNotSupported.new "body is not handled for #{self.debug_info}"
@@ -425,6 +427,7 @@ module Parser::AST
         end
       when Array
         return false unless expected.length == actual.length
+
         actual.zip(expected).all? { |a, e| match_value?(a, e) }
       when NilClass
         actual.nil?

--- a/lib/synvert/core/rewriter/scope/goto_scope.rb
+++ b/lib/synvert/core/rewriter/scope/goto_scope.rb
@@ -18,6 +18,7 @@ module Synvert::Core
     def process
       current_node = @instance.current_node
       return unless current_node
+
       child_node = current_node.send @child_node_name
       @instance.process_with_other_node child_node do
         @instance.instance_eval &@block

--- a/lib/synvert/core/rewriter/scope/within_scope.rb
+++ b/lib/synvert/core/rewriter/scope/within_scope.rb
@@ -19,6 +19,7 @@ module Synvert::Core
     def process
       current_node = @instance.current_node
       return unless current_node
+
       @instance.process_with_node current_node do
         matching_nodes = []
         matching_nodes << current_node if current_node.match? @rules


### PR DESCRIPTION
Auto corrected by following Lint Ruby EmptyLine

Click [here](https://awesomecode.io/repos/xinminlabs/synvert-core/config_groups/ruby/371) to configure it on awesomecode.io