### PR TITLE
Auto corrected by following Lint Ruby Parentheses

### DIFF
--- a/spec/synvert/core/configuration_spec.rb
+++ b/spec/synvert/core/configuration_spec.rb
@@ -4,7 +4,7 @@ module Synvert::Core
   describe Configuration do
     it 'sets / gets' do
       Configuration.instance.set :key, 'value'
-      expect(Configuration.instance.get :key).to eq 'value'
+      expect(Configuration.instance.get(:key)).to eq 'value'
     end
   end
 end

--- a/spec/synvert/core/rewriter/instance_spec.rb
+++ b/spec/synvert/core/rewriter/instance_spec.rb
@@ -205,7 +205,7 @@ end
         instance.instance_variable_set :@actions, [action1, action2, action3]
         conflict_actions = instance.send(:get_conflict_actions)
         expect(conflict_actions).to eq []
-        expect(instance.instance_variable_get :@actions).to eq [action1, action2, action3]
+        expect(instance.instance_variable_get(:@actions)).to eq [action1, action2, action3]
       end
 
       it "has no conflict" do
@@ -216,7 +216,7 @@ end
         instance.instance_variable_set :@actions, [action1, action2, action3]
         conflict_actions = instance.send(:get_conflict_actions)
         expect(conflict_actions).to eq [action2, action1]
-        expect(instance.instance_variable_get :@actions).to eq [action3]
+        expect(instance.instance_variable_get(:@actions)).to eq [action3]
       end
     end
 

--- a/spec/synvert/core/rewriter_spec.rb
+++ b/spec/synvert/core/rewriter_spec.rb
@@ -92,7 +92,7 @@ module Synvert::Core
           add_file 'foo.bar', 'FooBar'
         end
         rewriter.process
-        expect(File.read './foo.bar').to eq 'FooBar'
+        expect(File.read('./foo.bar')).to eq 'FooBar'
         FileUtils.rm './foo.bar'
       end
 
@@ -112,7 +112,7 @@ module Synvert::Core
           remove_file 'foo.bar'
         end
         rewriter.process
-        expect(File.exist? './foo.bar').to be_falsey
+        expect(File.exist?('./foo.bar')).to be_falsey
       end
 
       it 'does nothing if file not exist' do
@@ -120,7 +120,7 @@ module Synvert::Core
           remove_file 'foo.bar'
         end
         rewriter.process
-        expect(File.exist? './foo.bar').to be_falsey
+        expect(File.exist?('./foo.bar')).to be_falsey
       end
 
       it 'does nothing in sandbox mode' do
@@ -204,11 +204,11 @@ module Synvert::Core
       context "exist?" do
         it 'returns true if rewriter exists' do
           Rewriter.new 'group', 'rewriter'
-          expect(Rewriter.exist? 'group', 'rewriter').to be_truthy
+          expect(Rewriter.exist?('group', 'rewriter')).to be_truthy
         end
 
         it 'returns false if rewriter does not exist' do
-          expect(Rewriter.exist? 'group', 'rewriter').to be_falsey
+          expect(Rewriter.exist?('group', 'rewriter')).to be_falsey
         end
       end
 


### PR DESCRIPTION
Auto corrected by following Lint Ruby Parentheses

Click [here](https://awesomecode.io/repos/xinminlabs/synvert-core/config_groups/ruby/372) to configure it on awesomecode.io