### PR TITLE
Auto corrected by following Lint Ruby Lint/DeprecatedClassMethods

### DIFF
--- a/lib/synvert/core/rewriter/gem_spec.rb
+++ b/lib/synvert/core/rewriter/gem_spec.rb
@@ -27,7 +27,7 @@ module Synvert::Core
     # @raise [Synvert::Core::GemfileLockNotFound] raise if Gemfile.lock does not exist.
     def match?
       gemfile_lock_path = File.join(Configuration.instance.get(:path), 'Gemfile.lock')
-      if File.exists? gemfile_lock_path
+      if File.exist? gemfile_lock_path
         parser = Bundler::LockfileParser.new(File.read(gemfile_lock_path))
         if spec = parser.specs.find { |spec| spec.name == @name }
           Gem::Version.new(spec.version).send(OPERATORS[@operator], @version)


### PR DESCRIPTION
Auto corrected by following Lint Ruby Lint/DeprecatedClassMethods

Click [here](https://awesomecode.io/repos/xinminlabs/synvert-core/lint_configs/ruby/6719) to configure it on awesomecode.io