### PR TITLE
Auto corrected by following Lint Ruby Style/SafeNavigation

### DIFF
--- a/lib/synvert/core/node_ext.rb
+++ b/lib/synvert/core/node_ext.rb
@@ -297,9 +297,7 @@ module Parser::AST
     #
     # @return [String] source code.
     def to_source
-      if self.loc.expression
-        self.loc.expression.source
-      end
+      self.loc.expression&.source
     end
 
     # Get the indent of current node.

--- a/lib/synvert/core/rewriter/condition/if_exist_condition.rb
+++ b/lib/synvert/core/rewriter/condition/if_exist_condition.rb
@@ -7,7 +7,7 @@ module Synvert::Core
     def match?
       match = false
       @instance.current_node.recursive_children do |child_node|
-        match = match || (child_node && child_node.match?(@rules))
+        match = match || (child_node&.match?(@rules))
       end
       match
     end

--- a/lib/synvert/core/rewriter/condition/unless_exist_condition.rb
+++ b/lib/synvert/core/rewriter/condition/unless_exist_condition.rb
@@ -7,7 +7,7 @@ module Synvert::Core
     def match?
       match = false
       @instance.current_node.recursive_children do |child_node|
-        match = match || (child_node && child_node.match?(@rules))
+        match = match || (child_node&.match?(@rules))
       end
       !match
     end


### PR DESCRIPTION
Auto corrected by following Lint Ruby Style/SafeNavigation

Click [here](https://awesomecode.io/repos/xinminlabs/synvert-core/lint_configs/ruby/22059) to configure it on awesomecode.io