### PR TITLE
Auto corrected by following Lint Ruby Style/Encoding

### DIFF
--- a/lib/synvert/core/configuration.rb
+++ b/lib/synvert/core/configuration.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # frozen_string_literal: true
 
 require 'singleton'

--- a/lib/synvert/core/engine.rb
+++ b/lib/synvert/core/engine.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # frozen_string_literal: true
 
 module Synvert::Core

--- a/lib/synvert/core/engine/erb.rb
+++ b/lib/synvert/core/engine/erb.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # frozen_string_literal: true
 
 require 'erubis'

--- a/lib/synvert/core/rewriter.rb
+++ b/lib/synvert/core/rewriter.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # frozen_string_literal: true
 
 module Synvert::Core

--- a/lib/synvert/core/rewriter/action.rb
+++ b/lib/synvert/core/rewriter/action.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # frozen_string_literal: true
 
 module Synvert::Core

--- a/lib/synvert/core/rewriter/action/append_action.rb
+++ b/lib/synvert/core/rewriter/action/append_action.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # frozen_string_literal: true
 
 module Synvert::Core

--- a/lib/synvert/core/rewriter/action/insert_action.rb
+++ b/lib/synvert/core/rewriter/action/insert_action.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # frozen_string_literal: true
 
 module Synvert::Core

--- a/lib/synvert/core/rewriter/action/insert_after_action.rb
+++ b/lib/synvert/core/rewriter/action/insert_after_action.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # frozen_string_literal: true
 
 module Synvert::Core

--- a/lib/synvert/core/rewriter/action/remove_action.rb
+++ b/lib/synvert/core/rewriter/action/remove_action.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # frozen_string_literal: true
 
 module Synvert::Core

--- a/lib/synvert/core/rewriter/action/replace_erb_stmt_with_expr_action.rb
+++ b/lib/synvert/core/rewriter/action/replace_erb_stmt_with_expr_action.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # frozen_string_literal: true
 
 module Synvert::Core

--- a/lib/synvert/core/rewriter/action/replace_with_action.rb
+++ b/lib/synvert/core/rewriter/action/replace_with_action.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # frozen_string_literal: true
 
 module Synvert::Core

--- a/lib/synvert/core/rewriter/condition.rb
+++ b/lib/synvert/core/rewriter/condition.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # frozen_string_literal: true
 
 module Synvert::Core

--- a/lib/synvert/core/rewriter/condition/if_exist_condition.rb
+++ b/lib/synvert/core/rewriter/condition/if_exist_condition.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # frozen_string_literal: true
 
 module Synvert::Core

--- a/lib/synvert/core/rewriter/condition/if_only_exist_condition.rb
+++ b/lib/synvert/core/rewriter/condition/if_only_exist_condition.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # frozen_string_literal: true
 
 module Synvert::Core

--- a/lib/synvert/core/rewriter/condition/unless_exist_condition.rb
+++ b/lib/synvert/core/rewriter/condition/unless_exist_condition.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # frozen_string_literal: true
 
 module Synvert::Core

--- a/lib/synvert/core/rewriter/gem_spec.rb
+++ b/lib/synvert/core/rewriter/gem_spec.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # frozen_string_literal: true
 
 module Synvert::Core

--- a/lib/synvert/core/rewriter/helper.rb
+++ b/lib/synvert/core/rewriter/helper.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # frozen_string_literal: true
 
 module Synvert::Core

--- a/lib/synvert/core/rewriter/instance.rb
+++ b/lib/synvert/core/rewriter/instance.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # frozen_string_literal: true
 
 module Synvert::Core

--- a/lib/synvert/core/rewriter/ruby_version.rb
+++ b/lib/synvert/core/rewriter/ruby_version.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # frozen_string_literal: true
 
 module Synvert::Core

--- a/lib/synvert/core/rewriter/scope.rb
+++ b/lib/synvert/core/rewriter/scope.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # frozen_string_literal: true
 
 module Synvert::Core

--- a/lib/synvert/core/rewriter/scope/goto_scope.rb
+++ b/lib/synvert/core/rewriter/scope/goto_scope.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # frozen_string_literal: true
 
 module Synvert::Core

--- a/lib/synvert/core/rewriter/scope/within_scope.rb
+++ b/lib/synvert/core/rewriter/scope/within_scope.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # frozen_string_literal: true
 
 module Synvert::Core

--- a/lib/synvert/core/rewriter/warning.rb
+++ b/lib/synvert/core/rewriter/warning.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # frozen_string_literal: true
 
 module Synvert::Core

--- a/lib/synvert/core/version.rb
+++ b/lib/synvert/core/version.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 # frozen_string_literal: true
 
 module Synvert


### PR DESCRIPTION
Auto corrected by following Lint Ruby Style/Encoding

Click [here](https://awesomecode.io/repos/xinminlabs/synvert-core/lint_configs/ruby/16274) to configure it on awesomecode.io