### PR TITLE
Auto corrected by following Lint Ruby Style/Alias

### DIFF
--- a/lib/synvert/core/rewriter.rb
+++ b/lib/synvert/core/rewriter.rb
@@ -218,7 +218,7 @@ module Synvert::Core
     end
 
     # Parse within_file dsl, it finds a specifiled file.
-    alias_method :within_file, :within_files
+    alias within_file within_files
 
     # Parses add_file dsl, it adds a new file.
     #

--- a/lib/synvert/core/rewriter/instance.rb
+++ b/lib/synvert/core/rewriter/instance.rb
@@ -174,7 +174,7 @@ module Synvert::Core
       Rewriter::GotoScope.new(self, child_node_name, &block).process
     end
 
-    alias_method :with_node, :within_node
+    alias with_node within_node
 
     # Parse if_exist_node dsl, it creates a [Synvert::Core::Rewriter::IfExistCondition] to check
     # if matching nodes exist in the child nodes, if so, then continue operating on each matching ast node.


### PR DESCRIPTION
Auto corrected by following Lint Ruby Style/Alias

Click [here](https://awesomecode.io/repos/xinminlabs/synvert-core/lint_configs/ruby/13609) to configure it on awesomecode.io