### PR TITLE
Auto corrected by following Lint Ruby Style/Next

### DIFF
--- a/lib/synvert/core/node_ext.rb
+++ b/lib/synvert/core/node_ext.rb
@@ -236,7 +236,7 @@ module Parser::AST
     # @return [Parser::AST::Node] variable nodes.
     # @raise [Synvert::Core::MethodNotSupported] if calls on other node.
     def left_value
-      if [:masgn, :lvasgn, :ivasgn].include? self.type
+      if %i[masgn lvasgn ivasgn].include? self.type
         self.children[0]
       else
         raise Synvert::Core::MethodNotSupported.new "left_value is not handled for #{self.debug_info}"
@@ -248,7 +248,7 @@ module Parser::AST
     # @return [Array<Parser::AST::Node>] variable nodes.
     # @raise [Synvert::Core::MethodNotSupported] if calls on other node.
     def right_value
-      if [:masgn, :lvasgn, :ivasgn].include? self.type
+      if %i[masgn lvasgn ivasgn].include? self.type
         self.children[1]
       else
         raise Synvert::Core::MethodNotSupported.new "right_value is not handled for #{self.debug_info}"

--- a/lib/synvert/core/rewriter/action/append_action.rb
+++ b/lib/synvert/core/rewriter/action/append_action.rb
@@ -30,7 +30,7 @@ module Synvert::Core
     # @param node [Parser::AST::Node]
     # @return [String] n times whitesphace
     def indent(node)
-      if [:block, :class].include? node.type
+      if %i[block class].include? node.type
         ' ' * (node.indent + DEFAULT_INDENT)
       else
         ' ' * node.indent

--- a/lib/synvert/core/rewriter/action/insert_action.rb
+++ b/lib/synvert/core/rewriter/action/insert_action.rb
@@ -33,7 +33,7 @@ module Synvert::Core
     # @param node [Parser::AST::Node]
     # @return [String] n times whitesphace
     def indent(node)
-      if [:block, :class].include? node.type
+      if %i[block class].include? node.type
         ' ' * (node.indent + DEFAULT_INDENT)
       else
         ' ' * node.indent

--- a/lib/synvert/core/rewriter/instance.rb
+++ b/lib/synvert/core/rewriter/instance.rb
@@ -88,39 +88,38 @@ module Synvert::Core
     def process
       file_pattern = File.join(Configuration.instance.get(:path), @file_pattern)
       Dir.glob(file_pattern).each do |file_path|
-        unless Configuration.instance.get(:skip_files).include? file_path
-          begin
-            conflict_actions = []
-            source = self.class.file_source(file_path)
-            ast = self.class.file_ast(file_path)
+        next if Configuration.instance.get(:skip_files).include? file_path
+        begin
+          conflict_actions = []
+          source = self.class.file_source(file_path)
+          ast = self.class.file_ast(file_path)
 
-            @current_file = file_path
+          @current_file = file_path
 
-            process_with_node ast do
-              begin
-                instance_eval &@block
-              rescue NoMethodError
-                puts @current_node.debug_info
-                raise
-              end
+          process_with_node ast do
+            begin
+              instance_eval &@block
+            rescue NoMethodError
+              puts @current_node.debug_info
+              raise
             end
+          end
 
-            if @actions.length > 0
-              @actions.sort_by! { |action| action.send(@options[:sort_by]) }
-              conflict_actions = get_conflict_actions
-              @actions.reverse.each do |action|
-                source[action.begin_pos...action.end_pos] = action.rewritten_code
-                source = remove_code_or_whole_line(source, action.line)
-              end
-              @actions = []
-
-              self.class.write_file(file_path, source)
+          if @actions.length > 0
+            @actions.sort_by! { |action| action.send(@options[:sort_by]) }
+            conflict_actions = get_conflict_actions
+            @actions.reverse.each do |action|
+              source[action.begin_pos...action.end_pos] = action.rewritten_code
+              source = remove_code_or_whole_line(source, action.line)
             end
-          rescue Parser::SyntaxError
-            puts "[Warn] file #{file_path} was not parsed correctly."
-            # do nothing, iterate next file
-          end while !conflict_actions.empty?
-        end
+            @actions = []
+
+            self.class.write_file(file_path, source)
+          end
+        rescue Parser::SyntaxError
+          puts "[Warn] file #{file_path} was not parsed correctly."
+          # do nothing, iterate next file
+        end while !conflict_actions.empty?
       end
     end
 

--- a/spec/synvert/core/node_ext_spec.rb
+++ b/spec/synvert/core/node_ext_spec.rb
@@ -102,12 +102,12 @@ describe Parser::AST::Node do
   describe '#arguments' do
     it 'gets for def node' do
       node = parse("def test(foo, bar); foo + bar; end")
-      expect(node.arguments.map { |argument| argument.to_source }).to eq ['foo', 'bar']
+      expect(node.arguments.map { |argument| argument.to_source }).to eq %w[foo bar]
     end
 
     it 'gets for defs node' do
       node = parse("def self.test(foo, bar); foo + bar; end")
-      expect(node.arguments.map { |argument| argument.to_source }).to eq ['foo', 'bar']
+      expect(node.arguments.map { |argument| argument.to_source }).to eq %w[foo bar]
     end
 
     it 'gets for block node' do


### PR DESCRIPTION
Auto corrected by following Lint Ruby Style/Next

Click [here](https://awesomecode.io/repos/xinminlabs/synvert-core/lint_configs/ruby/19654) to configure it on awesomecode.io