### PR TITLE
Auto corrected by following Lint Ruby Style/RaiseArgs

### DIFF
--- a/lib/synvert/core/node_ext.rb
+++ b/lib/synvert/core/node_ext.rb
@@ -39,7 +39,7 @@ module Parser::AST
       when :mlhs
         self
       else
-        raise Synvert::Core::MethodNotSupported.new "name is not handled for #{self.debug_info}"
+        raise Synvert::Core::MethodNotSupported, "name is not handled for #{self.debug_info}"
       end
     end
 
@@ -51,7 +51,7 @@ module Parser::AST
       if :class == self.type
         self.children[1]
       else
-        raise Synvert::Core::MethodNotSupported.new "parent_class is not handled for #{self.debug_info}"
+        raise Synvert::Core::MethodNotSupported, "parent_class is not handled for #{self.debug_info}"
       end
     end
 
@@ -63,7 +63,7 @@ module Parser::AST
       if :const == self.type
         self.children[0]
       else
-        raise Synvert::Core::MethodNotSupported.new "parent_const is not handled for #{self.debug_info}"
+        raise Synvert::Core::MethodNotSupported, "parent_const is not handled for #{self.debug_info}"
       end
     end
 
@@ -75,7 +75,7 @@ module Parser::AST
       if :send == self.type
         self.children[0]
       else
-        raise Synvert::Core::MethodNotSupported.new "receiver is not handled for #{self.debug_info}"
+        raise Synvert::Core::MethodNotSupported, "receiver is not handled for #{self.debug_info}"
       end
     end
 
@@ -90,7 +90,7 @@ module Parser::AST
       when :send
         self.children[1]
       else
-        raise Synvert::Core::MethodNotSupported.new "message is not handled for #{self.debug_info}"
+        raise Synvert::Core::MethodNotSupported, "message is not handled for #{self.debug_info}"
       end
     end
 
@@ -109,7 +109,7 @@ module Parser::AST
       when :defined?
         self.children
       else
-        raise Synvert::Core::MethodNotSupported.new "arguments is not handled for #{self.debug_info}"
+        raise Synvert::Core::MethodNotSupported, "arguments is not handled for #{self.debug_info}"
       end
     end
 
@@ -121,7 +121,7 @@ module Parser::AST
       if :block == self.type
         self.children[0]
       else
-        raise Synvert::Core::MethodNotSupported.new "caller is not handled for #{self.debug_info}"
+        raise Synvert::Core::MethodNotSupported, "caller is not handled for #{self.debug_info}"
       end
     end
 
@@ -142,7 +142,7 @@ module Parser::AST
 
         :begin == self.children[3].type ? self.children[3].body : self.children[3..-1]
       else
-        raise Synvert::Core::MethodNotSupported.new "body is not handled for #{self.debug_info}"
+        raise Synvert::Core::MethodNotSupported, "body is not handled for #{self.debug_info}"
       end
     end
 
@@ -154,7 +154,7 @@ module Parser::AST
       if :if == self.type
         self.children[0]
       else
-        raise Synvert::Core::MethodNotSupported.new "condition is not handled for #{self.debug_info}"
+        raise Synvert::Core::MethodNotSupported, "condition is not handled for #{self.debug_info}"
       end
     end
 
@@ -166,7 +166,7 @@ module Parser::AST
       if :hash == self.type
         self.children.map { |child| child.children[0] }
       else
-        raise Synvert::Core::MethodNotSupported.new "keys is not handled for #{self.debug_info}"
+        raise Synvert::Core::MethodNotSupported, "keys is not handled for #{self.debug_info}"
       end
     end
 
@@ -178,7 +178,7 @@ module Parser::AST
       if :hash == self.type
         self.children.map { |child| child.children[1] }
       else
-        raise Synvert::Core::MethodNotSupported.new "keys is not handled for #{self.debug_info}"
+        raise Synvert::Core::MethodNotSupported, "keys is not handled for #{self.debug_info}"
       end
     end
 
@@ -191,7 +191,7 @@ module Parser::AST
       if :hash == self.type
         self.children.any? { |pair_node| pair_node.key.to_value == key }
       else
-        raise Synvert::Core::MethodNotSupported.new "has_key? is not handled for #{self.debug_info}"
+        raise Synvert::Core::MethodNotSupported, "has_key? is not handled for #{self.debug_info}"
       end
     end
 
@@ -205,7 +205,7 @@ module Parser::AST
         value_node = self.children.find { |pair_node| pair_node.key.to_value == key }
         value_node ? value_node.value : nil
       else
-        raise Synvert::Core::MethodNotSupported.new "has_key? is not handled for #{self.debug_info}"
+        raise Synvert::Core::MethodNotSupported, "has_key? is not handled for #{self.debug_info}"
       end
     end
 
@@ -217,7 +217,7 @@ module Parser::AST
       if :pair == self.type
         self.children.first
       else
-        raise Synvert::Core::MethodNotSupported.new "key is not handled for #{self.debug_info}"
+        raise Synvert::Core::MethodNotSupported, "key is not handled for #{self.debug_info}"
       end
     end
 
@@ -229,7 +229,7 @@ module Parser::AST
       if :pair == self.type
         self.children.last
       else
-        raise Synvert::Core::MethodNotSupported.new "value is not handled for #{self.debug_info}"
+        raise Synvert::Core::MethodNotSupported, "value is not handled for #{self.debug_info}"
       end
     end
 
@@ -241,7 +241,7 @@ module Parser::AST
       if %i[masgn lvasgn ivasgn].include? self.type
         self.children[0]
       else
-        raise Synvert::Core::MethodNotSupported.new "left_value is not handled for #{self.debug_info}"
+        raise Synvert::Core::MethodNotSupported, "left_value is not handled for #{self.debug_info}"
       end
     end
 
@@ -253,7 +253,7 @@ module Parser::AST
       if %i[masgn lvasgn ivasgn].include? self.type
         self.children[1]
       else
-        raise Synvert::Core::MethodNotSupported.new "right_value is not handled for #{self.debug_info}"
+        raise Synvert::Core::MethodNotSupported, "right_value is not handled for #{self.debug_info}"
       end
     end
 
@@ -276,7 +276,7 @@ module Parser::AST
       when :begin
         self.children.first.to_value
       else
-        raise Synvert::Core::MethodNotSupported.new "to_value is not handled for #{self.debug_info}"
+        raise Synvert::Core::MethodNotSupported, "to_value is not handled for #{self.debug_info}"
       end
     end
 
@@ -389,7 +389,7 @@ module Parser::AST
           when NilClass
             'nil'
           else
-            raise Synvert::Core::MethodNotSupported.new "rewritten_source is not handled for #{evaluated.inspect}"
+            raise Synvert::Core::MethodNotSupported, "rewritten_source is not handled for #{evaluated.inspect}"
           end
         else
           "{{#{old_code}}}"
@@ -446,7 +446,7 @@ module Parser::AST
       when Parser::AST::Node
         actual == expected
       else
-        raise Synvert::Core::MethodNotSupported.new "#{expected.class} is not handled for match_value?"
+        raise Synvert::Core::MethodNotSupported, "#{expected.class} is not handled for match_value?"
       end
     end
 

--- a/lib/synvert/core/rewriter.rb
+++ b/lib/synvert/core/rewriter.rb
@@ -65,7 +65,7 @@ module Synvert::Core
         if exist? group, name
           rewriters[group][name]
         else
-          raise RewriterNotFound.new "Rewriter #{group} #{name} not found"
+          raise RewriterNotFound, "Rewriter #{group} #{name} not found"
         end
       end
 
@@ -82,7 +82,7 @@ module Synvert::Core
           rewriter.process
           rewriter
         else
-          raise RewriterNotFound.new "Rewriter #{group}/#{name} not found"
+          raise RewriterNotFound, "Rewriter #{group}/#{name} not found"
         end
       end
 

--- a/lib/synvert/core/rewriter/gem_spec.rb
+++ b/lib/synvert/core/rewriter/gem_spec.rb
@@ -35,7 +35,7 @@ module Synvert::Core
           false
         end
       else
-        raise GemfileLockNotFound.new 'Gemfile.lock does not exist'
+        raise GemfileLockNotFound, 'Gemfile.lock does not exist'
       end
     end
   end


### PR DESCRIPTION
Auto corrected by following Lint Ruby Style/RaiseArgs

Click [here](https://awesomecode.io/repos/xinminlabs/synvert-core/lint_configs/ruby/20824) to configure it on awesomecode.io