### PR TITLE
Auto corrected by following Lint Ruby Layout/LeadingCommentSpace

### DIFF
--- a/spec/synvert/core/rewriter_spec.rb
+++ b/spec/synvert/core/rewriter_spec.rb
@@ -14,7 +14,7 @@ module Synvert::Core
     end
 
     it 'parses if_ruby' do
-      #stub_const("RUBY_VERSION", '2.0.0')
+      # stub_const("RUBY_VERSION", '2.0.0')
       rewriter =
         Rewriter.new 'group', 'name' do
           if_ruby '2.0.0'


### PR DESCRIPTION
Auto corrected by following Lint Ruby Layout/LeadingCommentSpace

Click [here](https://awesomecode.io/repos/xinminlabs/synvert-core/lint_configs/ruby/3599) to configure it on awesomecode.io