### PR TITLE
Auto corrected by following Lint Ruby Lint/UnusedBlockArgument

### DIFF
--- a/spec/synvert/core/rewriter_spec.rb
+++ b/spec/synvert/core/rewriter_spec.rb
@@ -190,7 +190,7 @@ module Synvert::Core
     it 'parses helper_method' do
       rewriter =
         Rewriter.new 'group', 'name' do
-          helper_method 'dynamic_helper' do |arg1, arg2|
+          helper_method 'dynamic_helper' do |_arg1, _arg2|
             'dynamic result'
           end
         end


### PR DESCRIPTION
Auto corrected by following Lint Ruby Lint/UnusedBlockArgument

Click [here](https://awesomecode.io/repos/xinminlabs/synvert-core/lint_configs/ruby/10814) to configure it on awesomecode.io