### PR TITLE
Auto corrected by following Lint Ruby Style/Alias

### DIFF
--- a/lib/synvert/core/rewriter.rb
+++ b/lib/synvert/core/rewriter.rb
@@ -217,7 +217,7 @@ module Synvert::Core
     end
 
     # Parse within_file dsl, it finds a specifiled file.
-    alias_method :within_file, :within_files
+    alias within_file within_files
 
     # Parses add_file dsl, it adds a new file.
     #

--- a/lib/synvert/core/rewriter/instance.rb
+++ b/lib/synvert/core/rewriter/instance.rb
@@ -167,7 +167,7 @@ module Synvert::Core
       Rewriter::WithinScope.new(self, rules, { recursive: true }, &block).process
     end
 
-    alias_method :with_node, :within_node
+    alias with_node within_node
 
     # Parse within_direct_node dsl, it creates a [Synvert::Core::Rewriter::WithinScope] to find direct matching ast nodes,
     # then continue operating on each matching ast node.
@@ -178,7 +178,7 @@ module Synvert::Core
       Rewriter::WithinScope.new(self, rules, { recursive: false }, &block).process
     end
 
-    alias_method :with_direct_node, :within_direct_node
+    alias with_direct_node within_direct_node
 
     # Parse goto_node dsl, it creates a [Synvert::Core::Rewriter::GotoScope] to go to a child node,
     # then continue operating on the child node.


### PR DESCRIPTION
Auto corrected by following Lint Ruby Style/Alias

Click [here](https://awesomecode.io/repos/xinminlabs/synvert-core/lint_configs/ruby/13609) to configure it on awesomecode.io