### PR TITLE
Auto corrected by following Lint Ruby EmptyLine

### DIFF
--- a/lib/synvert/core/rewriter/instance.rb
+++ b/lib/synvert/core/rewriter/instance.rb
@@ -91,6 +91,7 @@ module Synvert::Core
         .glob(file_pattern)
         .each do |file_path|
           next if Configuration.instance.get(:skip_files).include? file_path
+
           begin
             conflict_actions = []
             source = +self.class.file_source(file_path)


### PR DESCRIPTION
Auto corrected by following Lint Ruby EmptyLine

Click [here](https://awesomecode.io/repos/xinminlabs/synvert-core/config_groups/ruby/371) to configure it on awesomecode.io