### PR TITLE
Auto corrected by following Lint Ruby Style/ExplicitBlockArgument

### DIFF
--- a/lib/synvert/core/node_ext.rb
+++ b/lib/synvert/core/node_ext.rb
@@ -321,11 +321,11 @@ module Parser::AST
     #
     # @yield [child] Gives a child node.
     # @yieldparam child [Parser::AST::Node] child node
-    def recursive_children
+    def recursive_children(&block)
       children.each do |child|
         if Parser::AST::Node === child
           yield child
-          child.recursive_children { |c| yield c }
+          child.recursive_children(&block)
         end
       end
     end


### PR DESCRIPTION
Auto corrected by following Lint Ruby Style/ExplicitBlockArgument

Click [here](https://awesomecode.io/repos/xinminlabs/synvert-core/lint_configs/ruby/109015) to configure it on awesomecode.io