### PR TITLE
Auto corrected by following Lint Ruby Style/Encoding

### DIFF
--- a/synvert-core.gemspec
+++ b/synvert-core.gemspec
@@ -1,4 +1,3 @@
-# coding: utf-8
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'synvert/core/version'


### PR DESCRIPTION
Auto corrected by following Lint Ruby Style/Encoding

Click [here](https://awesomecode.io/repos/xinminlabs/synvert-core/lint_configs/ruby/16274) to configure it on awesomecode.io