### PR TITLE
Auto corrected by following Lint Ruby EmptyLine

### DIFF
--- a/lib/synvert/core/node_ext.rb
+++ b/lib/synvert/core/node_ext.rb
@@ -348,6 +348,7 @@ module Parser::AST
           end
           # arguments
           return nil if child_node.empty?
+
           return Parser::Source::Range.new('(string)', child_node.first.loc.expression.begin_pos, child_node.last.loc.expression.end_pos)
         end
 


### PR DESCRIPTION
Auto corrected by following Lint Ruby EmptyLine

Click [here](https://awesomecode.io/repos/xinminlabs/synvert-core/config_groups/ruby/371) to configure it on awesomecode.io