### PR TITLE
Auto corrected by following Lint Ruby EmptyLine

### DIFF
--- a/lib/synvert/core/node_ext.rb
+++ b/lib/synvert/core/node_ext.rb
@@ -347,6 +347,7 @@ module Parser::AST
         if respond_to?(child_name)
           child_node = send(child_name)
           return nil if child_node.nil?
+
           if child_node.is_a?(Parser::AST::Node)
             return(
               Parser::Source::Range.new(


### PR DESCRIPTION
Auto corrected by following Lint Ruby EmptyLine

Click [here](https://awesomecode.io/repos/xinminlabs/synvert-core/config_groups/ruby/371) to configure it on awesomecode.io