### PR TITLE
Auto corrected by following Lint Ruby EmptyLine

### DIFF
--- a/lib/synvert/core/node_ext.rb
+++ b/lib/synvert/core/node_ext.rb
@@ -289,6 +289,7 @@ module Parser::AST
         key = method_name.to_s.sub('_value', '')
         return hash_value(key.to_sym)&.to_value if key?(key.to_sym)
         return hash_value(key.to_s)&.to_value if key?(key.to_s)
+
         return nil
       end
 


### PR DESCRIPTION
Auto corrected by following Lint Ruby EmptyLine

Click [here](https://awesomecode.io/repos/xinminlabs/synvert-core/config_groups/ruby/371) to configure it on awesomecode.io